### PR TITLE
add full uuid macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ rust: nightly
 before_script:
   - rustup component add rustfmt-preview
 script:
-  - cargo fmt --all -- --write-mode=diff
-  - cargo test
+  - cargo fmt --all
+  - cargo test --features=nightly
   - cargo bench
 
 notifications:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,13 @@ name = "uuid_macro"
 repository = "https://github.com/uuid-rs/uuid_macro"
 version = "0.1.0"
 
-[lib]
-proc-macro = true
 
-[dependencies.syn]
-version = "0.13"
+[dependencies]
+uuid_macro_impl = { path = "./uuid_macro_impl"}
+proc-macro-hack = { version = "0.4"}
+uuid = { git = "https://github.com/mokeyish/uuid.git", branch = "master" }
+#uuid = { git = "https://github.com/mokeyish/uuid.git", branch = "master", features = ["nightly"] }
 
-[dependencies.quote]
-version = "0.5"
-
-[dependencies.proc-macro-hack]
-version = "0.4"
-
+[features]
+default = []
+nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ version = "0.1.0"
 [dependencies]
 uuid_macro_impl = { path = "./uuid_macro_impl"}
 proc-macro-hack = { version = "0.4"}
-uuid = { git = "https://github.com/uuid-rs/uuid.git", branch = "master" }
-#uuid = { git = "https://github.com/uuid-rs/uuid.git", branch = "master", features = ["nightly"] }
+uuid = { version = "0.6.5", features = ["const_fn"]}
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ version = "0.1.0"
 
 
 [dependencies]
-uuid_macro_impl = { path = "./uuid_macro_impl"}
-proc-macro-hack = { version = "0.4"}
-uuid = { version = "0.6.5", features = ["const_fn"]}
+uuid_macro_impl = { path = "./uuid_macro_impl" }
+proc-macro-hack = { version = "0.4" }
+uuid = { version = "0.6.5", features = ["const_fn"], default-features = false }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ version = "0.1.0"
 [dependencies]
 uuid_macro_impl = { path = "./uuid_macro_impl"}
 proc-macro-hack = { version = "0.4"}
-uuid = { git = "https://github.com/mokeyish/uuid.git", branch = "master" }
-#uuid = { git = "https://github.com/mokeyish/uuid.git", branch = "master", features = ["nightly"] }
+uuid = { git = "https://github.com/uuid-rs/uuid.git", branch = "master" }
+#uuid = { git = "https://github.com/uuid-rs/uuid.git", branch = "master", features = ["nightly"] }
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,15 @@ mod tests {
 
     #[cfg(feature = "nightly")]
     #[test]
-    fn test_const_uuid_macro_build(){
-        assert_eq!("f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4", format!("{:x}", CONST_UUID));
+    fn test_const_uuid_macro_build() {
+        assert_eq!(
+            "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4",
+            format!("{:x}", CONST_UUID)
+        );
     }
 
     #[test]
-    fn test_uuid_macro_build(){
+    fn test_uuid_macro_build() {
         let u: Uuid = uuid!("F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4");
         assert_eq!("f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4", format!("{:x}", u));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate uuid;
-pub use uuid::Uuid;
 
 #[macro_use]
 extern crate proc_macro_hack;
@@ -31,15 +30,16 @@ proc_macro_expr_decl! {
 macro_rules! uuid {
     {$literal:expr} => {
         {
+            use uuid;
             const BYTES: [u8; 16] = uuid_parts! {$literal};
-            $crate::Uuid::from_uuid_bytes(BYTES)
+            uuid::Uuid::from_uuid_bytes(BYTES)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::uuid::Uuid;
     #[cfg(feature = "nightly")]
     const CONST_UUID: Uuid = uuid!("F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,12 @@ proc_macro_expr_decl! {
 /// A literal syntax for generating UUID values.
 ///
 /// ```
+/// # extern crate uuid;
 /// # #[macro_use]
 /// # extern crate uuid_macro;
-/// # use uuid_macro::*;
+/// # use uuid::Uuid;
 /// # fn main() {
-/// #     let _ : Uuid = uuid!("6B29FC40-CA47-1067-B31D-00DD010662DA");
+/// #    let _ : Uuid = uuid!("6B29FC40-CA47-1067-B31D-00DD010662DA");
 /// # }
 /// ```
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,10 @@ proc_macro_expr_decl! {
 /// ```
 /// # #[macro_use]
 /// # extern crate uuid;
+/// # extern crate uuid_macro;
 /// # use uuid::Uuid;
 /// # fn main() {
-/// # let _ : Uuid =
-/// uuid!{"6B29FC40-CA47-1067-B31D-00DD010662DA"}
-/// # ;
+/// #     let _ : Uuid =uuid!("6B29FC40-CA47-1067-B31D-00DD010662DA");
 /// # }
 /// ```
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ extern crate uuid;
 extern crate proc_macro_hack;
 
 #[macro_use]
-#[allow(unused_imports)]
 extern crate uuid_macro_impl;
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,10 @@ proc_macro_expr_decl! {
 ///
 /// ```
 /// # #[macro_use]
-/// # extern crate uuid;
 /// # extern crate uuid_macro;
-/// # use uuid::Uuid;
+/// # use uuid_macro::*;
 /// # fn main() {
-/// #     let _ : Uuid =uuid!("6B29FC40-CA47-1067-B31D-00DD010662DA");
+/// #     let _ : Uuid = uuid!("6B29FC40-CA47-1067-B31D-00DD010662DA");
 /// # }
 /// ```
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate uuid;
 extern crate proc_macro_hack;
 
 #[macro_use]
+#[allow(unused_imports)]
 extern crate uuid_macro_impl;
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,101 +1,59 @@
-#![recursion_limit="128"]
+extern crate uuid;
+pub use uuid::Uuid;
 
 #[macro_use]
 extern crate proc_macro_hack;
+
 #[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
+#[allow(unused_imports)]
+extern crate uuid_macro_impl;
 
+#[doc(hidden)]
+#[allow(unused_imports)]
+use uuid_macro_impl::*;
 
-proc_macro_expr_impl! {
-    pub fn uuid_parts_impl(input: &str) -> String {
+proc_macro_expr_decl! {
+    #[doc(hidden)]
+    uuid_parts! => uuid_parts_impl
+}
 
-        let mut i = 0usize;
-        let mut bytes = [0u8; 16];
-
-        let hex = |m: char| {
-            match m {
-                '0' => 0u8,
-                '1' => 1u8,
-                '2' => 2u8,
-                '3' => 3u8,
-                '4' => 4u8,
-                '5' => 5u8,
-                '6' => 6u8,
-                '7' => 7u8,
-                '8' => 8u8,
-                '9' => 9u8,
-                'A' | 'a' => 10u8,
-                'B' | 'b' => 11u8,
-                'C' | 'c' => 12u8,
-                'D' | 'd' => 13u8,
-                'E' | 'e' => 14u8,
-                'F' | 'f' => 15u8,
-                _ => panic!("unexpected char.")
-            }
-        };
-        for c in input.chars() {
-            if c == '-' || c == '"' {
-                continue;
-            }
-            let index = i / 2;
-            if index >= 16 {
-                panic!("out ouf index.")
-            }
-            bytes[index] = if i % 2 == 0 {hex(c)} else { bytes[index] * 16 + hex(c) };
-            i += 1;
+/// A literal syntax for generating UUID values.
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate uuid;
+/// # use uuid::Uuid;
+/// # fn main() {
+/// # let _ : Uuid =
+/// uuid!{"6B29FC40-CA47-1067-B31D-00DD010662DA"}
+/// # ;
+/// # }
+/// ```
+#[macro_export]
+macro_rules! uuid {
+    {$literal:expr} => {
+        {
+            const BYTES: [u8; 16] = uuid_parts! {$literal};
+            $crate::Uuid::from_uuid_bytes(BYTES)
         }
+    }
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "nightly")]
+    const CONST_UUID: Uuid = uuid!("F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4");
 
+    #[cfg(feature = "nightly")]
+    #[test]
+    fn test_const_uuid_macro_build(){
+        assert_eq!("f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4", format!("{:x}", CONST_UUID));
+    }
 
-        let d0: u8  = bytes[0];
-        let d1: u8  = bytes[1];
-        let d2: u8  = bytes[2];
-        let d3: u8  = bytes[3];
-
-        // data1: u32
-
-        let d4: u8  = bytes[4];
-        let d5: u8  =  bytes[5];
-
-        // data2: u16
-
-        let d6: u8  = bytes[6];
-        let d7: u8  =  bytes[7];
-        // data3: u16
-
-        let data4_0: u8 = bytes[8];
-        let data4_1: u8 = bytes[9];
-        let data4_2: u8 = bytes[10];
-        let data4_3: u8 = bytes[11];
-        let data4_4: u8 = bytes[12];
-        let data4_5: u8 = bytes[13];
-        let data4_6: u8 = bytes[14];
-        let data4_7: u8 = bytes[15];
-        // data4: u64
-
-        (quote! {
-            [
-                #d0 as u8,
-                #d1 as u8,
-                #d2 as u8,
-                #d3 as u8,
-                #d4 as u8,
-                #d5 as u8,
-                #d6 as u8,
-                #d7 as u8,
-
-               #data4_0 as u8,
-               #data4_1 as u8,
-               #data4_2 as u8,
-               #data4_3 as u8,
-               #data4_4 as u8,
-               #data4_5 as u8,
-               #data4_6 as u8,
-               #data4_7 as u8
-               ]
-        }).to_string()
-
+    #[test]
+    fn test_uuid_macro_build(){
+        let u: Uuid = uuid!("F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4");
+        assert_eq!("f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4", format!("{:x}", u));
     }
 }

--- a/uuid_macro_impl/Cargo.toml
+++ b/uuid_macro_impl/Cargo.toml
@@ -12,9 +12,6 @@ version = "0.1.0"
 [lib]
 proc-macro = true
 
-[dependencies.syn]
-version = "0.13"
-
 [dependencies.quote]
 version = "0.5"
 

--- a/uuid_macro_impl/Cargo.toml
+++ b/uuid_macro_impl/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors = [
+    "Hunar Roop Kahlon <hunar.roop@gmail.com>",
+    "YISH <mokeyish@hotmail.com>"
+]
+description = "Procedural uuid!() macro for compile-time uuid creation"
+license = "Apache-2.0/MIT"
+name = "uuid_macro_impl"
+repository = "https://github.com/uuid-rs/uuid_macro"
+version = "0.1.0"
+
+[lib]
+proc-macro = true
+
+[dependencies.syn]
+version = "0.13"
+
+[dependencies.quote]
+version = "0.5"
+
+[dependencies.proc-macro-hack]
+version = "0.4"
+

--- a/uuid_macro_impl/src/lib.rs
+++ b/uuid_macro_impl/src/lib.rs
@@ -1,11 +1,10 @@
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
 #[macro_use]
 extern crate proc_macro_hack;
 
 #[macro_use]
 extern crate quote;
-
 
 proc_macro_expr_impl! {
     pub fn uuid_parts_impl(input: &str) -> String {

--- a/uuid_macro_impl/src/lib.rs
+++ b/uuid_macro_impl/src/lib.rs
@@ -1,0 +1,101 @@
+#![recursion_limit="128"]
+
+#[macro_use]
+extern crate proc_macro_hack;
+#[macro_use]
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+
+proc_macro_expr_impl! {
+    pub fn uuid_parts_impl(input: &str) -> String {
+
+        let mut i = 0usize;
+        let mut bytes = [0u8; 16];
+
+        let hex = |m: char| {
+            match m {
+                '0' => 0u8,
+                '1' => 1u8,
+                '2' => 2u8,
+                '3' => 3u8,
+                '4' => 4u8,
+                '5' => 5u8,
+                '6' => 6u8,
+                '7' => 7u8,
+                '8' => 8u8,
+                '9' => 9u8,
+                'A' | 'a' => 10u8,
+                'B' | 'b' => 11u8,
+                'C' | 'c' => 12u8,
+                'D' | 'd' => 13u8,
+                'E' | 'e' => 14u8,
+                'F' | 'f' => 15u8,
+                _ => panic!("unexpected char.")
+            }
+        };
+        for c in input.chars() {
+            if c == '-' || c == '"' {
+                continue;
+            }
+            let index = i / 2;
+            if index >= 16 {
+                panic!("out ouf index.")
+            }
+            bytes[index] = if i % 2 == 0 {hex(c)} else { bytes[index] * 16 + hex(c) };
+            i += 1;
+        }
+
+
+
+        let d0: u8  = bytes[0];
+        let d1: u8  = bytes[1];
+        let d2: u8  = bytes[2];
+        let d3: u8  = bytes[3];
+
+        // data1: u32
+
+        let d4: u8  = bytes[4];
+        let d5: u8  =  bytes[5];
+
+        // data2: u16
+
+        let d6: u8  = bytes[6];
+        let d7: u8  =  bytes[7];
+        // data3: u16
+
+        let data4_0: u8 = bytes[8];
+        let data4_1: u8 = bytes[9];
+        let data4_2: u8 = bytes[10];
+        let data4_3: u8 = bytes[11];
+        let data4_4: u8 = bytes[12];
+        let data4_5: u8 = bytes[13];
+        let data4_6: u8 = bytes[14];
+        let data4_7: u8 = bytes[15];
+        // data4: u64
+
+        (quote! {
+            [
+                #d0 as u8,
+                #d1 as u8,
+                #d2 as u8,
+                #d3 as u8,
+                #d4 as u8,
+                #d5 as u8,
+                #d6 as u8,
+                #d7 as u8,
+
+               #data4_0 as u8,
+               #data4_1 as u8,
+               #data4_2 as u8,
+               #data4_3 as u8,
+               #data4_4 as u8,
+               #data4_5 as u8,
+               #data4_6 as u8,
+               #data4_7 as u8
+               ]
+        }).to_string()
+
+    }
+}

--- a/uuid_macro_impl/src/lib.rs
+++ b/uuid_macro_impl/src/lib.rs
@@ -2,8 +2,7 @@
 
 #[macro_use]
 extern crate proc_macro_hack;
-#[macro_use]
-extern crate syn;
+
 #[macro_use]
 extern crate quote;
 


### PR DESCRIPTION
It depend on [ref const Uuid::from_uuid_bytes](https://github.com/uuid-rs/uuid/pull/218)

*The example*

```rust
extern crate uuid;
extern crate uuid_macro;

use uuid::Uuid;

// if you want to create const uuid value,just enable nightly feature.
const CONST_UUID: Uuid = uuid!("936DA01F9ABD4d9d80C702AF85C822A8");

fn main() {
    let my_uuid = uuid!("936DA01F9ABD4d9d80C702AF85C822A8")
    println!("Parsed a version {} UUID.", my_uuid.get_version_num());
    println!("{}", my_uuid);
}
```